### PR TITLE
feat(oauth2) add ability to persist refresh tokens

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -52,14 +52,10 @@ end
 
 
 local function generate_token(conf, service, credential, authenticated_userid,
-                              scope, state, expiration, disable_refresh)
+                              scope, state, existing_token, expiration,
+                              disable_refresh)
 
   local token_expiration = expiration or conf.token_expiration
-
-  local refresh_token
-  if not disable_refresh and token_expiration > 0 then
-    refresh_token = random_string()
-  end
 
   local refresh_token_ttl
   if conf.refresh_token_ttl and conf.refresh_token_ttl > 0 then
@@ -71,18 +67,38 @@ local function generate_token(conf, service, credential, authenticated_userid,
     service_id = service.id
   end
 
-  local token, err = kong.db.oauth2_tokens:insert({
-    service = service_id and { id = service_id } or nil,
-    credential = { id = credential.id },
-    authenticated_userid = authenticated_userid,
-    expires_in = token_expiration,
-    refresh_token = refresh_token,
-    scope = scope
-  }, {
-    -- Access tokens (and their associated refresh token) are being
-    -- permanently deleted after 'refresh_token_ttl' seconds
-    ttl = token_expiration > 0 and refresh_token_ttl or nil
-  })
+  local refresh_token
+  local token, err
+  if existing_token and conf.persistent_refresh_token then
+    token, err = kong.db.oauth2_tokens:update({
+      id = existing_token.id
+    }, {
+      access_token = random_string(),
+      expires_in = token_expiration,
+      created_at = timestamp.get_utc() / 1000
+    }, {
+      -- Access tokens (and their associated refresh token) are being
+      -- permanently deleted after 'refresh_token_ttl' seconds
+      ttl = token_expiration > 0 and refresh_token_ttl or nil
+    })
+    refresh_token = token.refresh_token  -- required for output
+  else
+    if not disable_refresh and token_expiration > 0 then
+      refresh_token = random_string()
+    end
+    token, err = kong.db.oauth2_tokens:insert({
+      service = service_id and { id = service_id } or nil,
+      credential = { id = credential.id },
+      authenticated_userid = authenticated_userid,
+      expires_in = token_expiration,
+      refresh_token = refresh_token,
+      scope = scope
+    }, {
+      -- Access tokens (and their associated refresh token) are being
+      -- permanently deleted after 'refresh_token_ttl' seconds
+      ttl = token_expiration > 0 and refresh_token_ttl or nil
+    })
+  end
 
   if err then
     return internal_server_error(err)
@@ -268,7 +284,7 @@ local function authorize(conf)
           response_params = generate_token(conf, kong.router.get_service(),
                                            client,
                                            parameters[AUTHENTICATED_USERID],
-                                           scopes, state, nil, true)
+                                           scopes, state, nil, nil, true)
           is_implicit_grant = true
         end
       end
@@ -484,7 +500,7 @@ local function issue_token(conf)
             response_params = generate_token(conf, kong.router.get_service(),
                                              client,
                                              parameters.authenticated_userid,
-                                             scope, state, nil, true)
+                                             scope, state, nil, nil, true)
           end
         end
 
@@ -547,9 +563,11 @@ local function issue_token(conf)
             response_params = generate_token(conf, kong.router.get_service(),
                                              client,
                                              token.authenticated_userid,
-                                             token.scope, state)
-            -- Delete old token
-            kong.db.oauth2_tokens:delete({ id = token.id })
+                                             token.scope, state, token)
+            -- Delete old token if refresh token not persisted
+            if not conf.persistent_refresh_token then
+              kong.db.oauth2_tokens:delete({ id = token.id })
+            end
           end
         end
       end

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -35,6 +35,7 @@ return {
           { global_credentials = { type = "boolean", default = false }, },
           { auth_header_name = { type = "string", default = "authorization" }, },
           { refresh_token_ttl = { type = "number", default = 1209600, required = true }, },
+          { persistent_refresh_token = { type = "boolean", default = false, required = false }, },
         },
         custom_validator = validate_flows,
         entity_checks = {

--- a/spec/03-plugins/25-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/25-oauth2/01-schema_spec.lua
@@ -72,6 +72,13 @@ for _, strategy in helpers.each_strategy() do
       assert.is_falsy(errors)
       assert.equal(1209600, t2.config.refresh_token_ttl)
     end)
+    it("defaults to non-persistent refresh tokens", function()
+      local t = {enable_authorization_code = true, mandatory_scope = false}
+      local t2, errors = v(t, schema_def)
+      assert.truthy(t2)
+      assert.is_falsy(errors)
+      assert.equal(false, t2.config.persistent_refresh_token)
+    end)
 
     describe("errors", function()
       it("requires at least one flow", function()

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -64,6 +64,30 @@ local function provision_token(host, extra_headers, client_id, client_secret)
 end
 
 
+local function refresh_token(host, refresh_token)
+  local request_client = helpers.proxy_ssl_client()
+  local res = assert(request_client:send {
+    method  = "POST",
+    path    = "/oauth2/token",
+    body    = {
+      refresh_token    = refresh_token,
+      client_id        = "clientid123",
+      client_secret    = "secret123",
+      grant_type       = "refresh_token"
+    },
+    headers = {
+      ["Host"]         = host or "oauth2.com",
+      ["Content-Type"] = "application/json"
+    }
+  })
+  assert.response(res).has.status(200)
+  local token = assert.response(res).has.jsonbody()
+  assert.is_table(token)
+  request_client:close()
+  return token
+end
+
+
 for _, strategy in helpers.each_strategy() do
 
 describe("Plugin: oauth2 [#" .. strategy .. "]", function()
@@ -169,6 +193,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       local service10   = admin_api.services:insert()
       local service11   = admin_api.services:insert()
       local service12   = admin_api.services:insert()
+      local service13   = admin_api.services:insert()
 
       local route1 = assert(admin_api.routes:insert({
         hosts     = { "oauth2.com" },
@@ -246,6 +271,12 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         hosts       = { "oauth2_12.com" },
         protocols   = { "http", "https" },
         service     = service12,
+      }))
+
+      local route13 = assert(admin_api.routes:insert({
+        hosts       = { "oauth2_13.com" },
+        protocols   = { "http", "https" },
+        service     = service13,
       }))
 
       admin_api.oauth2_plugins:insert({
@@ -344,6 +375,15 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           hide_credentials   = true,
         },
       })
+      admin_api.oauth2_plugins:insert({
+        route = { id = route13.id },
+        config   = {
+          scopes                   = { "email", "profile", "user.email" },
+          global_credentials       = true,
+          persistent_refresh_token = true,
+        },
+      })
+
 
       proxy_client     = helpers.proxy_client()
       proxy_ssl_client = helpers.proxy_ssl_client()
@@ -2256,6 +2296,62 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         assert.falsy(token.refresh_token == cjson.decode(body).refresh_token)
 
         assert.falsy(db.oauth2_tokens:select({ id = id }))
+      end)
+      it("does rewrite non-persistent refresh tokens", function ()
+        local token = provision_token()
+        local refreshed_token = refresh_token(nil, token.refresh_token)
+        assert.is_table(refreshed_token)
+        assert.falsy(token.refresh_token == refreshed_token.refresh_token)
+      end)
+      it("does not rewrite persistent refresh tokens", function()
+        local token = provision_token("oauth2_13.com")
+        local refreshed_token = refresh_token("oauth2_13.com", token.refresh_token)
+        local new_access_token = db.oauth2_tokens:select_by_access_token(refreshed_token.access_token)
+        local new_refresh_token = db.oauth2_tokens:select_by_refresh_token(token.refresh_token)
+        assert.truthy(new_refresh_token)
+        assert.same(new_access_token.id, new_refresh_token.id)
+
+
+        -- check refreshing sets created_at so access token doesn't expire
+        db.oauth2_tokens:update({
+          id = new_refresh_token.id
+        }, {
+          created_at = 123, -- set time as expired
+        })
+
+        local status, json, headers
+        helpers.wait_until(function()
+          local client = helpers.proxy_ssl_client()
+          local first_res = assert(client:send {
+            method  = "POST",
+            path    = "/request",
+            headers = {
+              ["Host"]      = "oauth2_13.com",
+              Authorization = "bearer " .. refreshed_token.access_token
+            }
+          })
+          local nbody = first_res:read_body()
+          status = first_res.status
+          headers = first_res.headers
+          json = cjson.decode(nbody)
+          client:close()
+          return status == 401
+        end, 7)
+        assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
+        assert.are.equal('Bearer realm="service" error="invalid_token" error_description="The access token is invalid or has expired"', headers['www-authenticate'])
+
+        local final_refreshed_token = refresh_token("oauth2_13.com", refreshed_token.refresh_token)
+        local last_res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"]      = "oauth2_13.com",
+            authorization = "bearer " .. final_refreshed_token.access_token
+          }
+        })
+        local last_body = cjson.decode(assert.res_status(200, last_res))
+        assert.equal("bearer " .. final_refreshed_token.access_token, last_body.headers.authorization)
+
       end)
     end)
 


### PR DESCRIPTION
### Summary
Add support for persisting oauth2 refresh tokens. Follows guidelines in [RFC6749](https://tools.ietf.org/html/rfc6749#section-6) to allow for the optional persistence of the refresh token when refreshing an access token.

### Related discussion
https://discuss.konghq.com/t/long-lived-refresh-tokens/659
https://discuss.konghq.com/t/long-lived-oauth-2-refresh-tokens/3005
